### PR TITLE
Fix/generic array body handling

### DIFF
--- a/src/__tests__/mcp-handler-real.test.ts
+++ b/src/__tests__/mcp-handler-real.test.ts
@@ -159,7 +159,9 @@ describe('MCPHandler (Real)', () => {
           required: []
         },
         _apiEndpoint: '/users/{id}',
-        _method: 'GET'
+        _method: 'GET',
+        _pathParams: ['id'],
+        _queryParams: ['include']
       };
 
       mcpHandler.registerTool('get_user', tool);

--- a/src/__tests__/mcp-handler.test.ts
+++ b/src/__tests__/mcp-handler.test.ts
@@ -272,7 +272,7 @@ describe('MCPHandler', () => {
       );
 
       const tools = await mcpHandler.listTools();
-      expect(tools).toHaveLength(2);
+      expect(tools).toHaveLength(6); // 2 from mock + 4 OpenAPI inspection tools
     });
 
     it('should pass options to OpenAPI loader', async () => {

--- a/src/__tests__/mcp-handler.test.ts
+++ b/src/__tests__/mcp-handler.test.ts
@@ -105,7 +105,8 @@ describe('MCPHandler', () => {
         description: 'Get users',
         inputSchema: { type: 'object', properties: {}, required: [] },
         _apiEndpoint: '/users',
-        _method: 'GET'
+        _method: 'GET',
+        _queryParams: ['limit']
       };
 
       mockSaasClient.call.mockResolvedValue({ users: [] });
@@ -149,7 +150,9 @@ describe('MCPHandler', () => {
         description: 'Get user by ID',
         inputSchema: { type: 'object', properties: {}, required: [] },
         _apiEndpoint: '/users/{id}',
-        _method: 'GET'
+        _method: 'GET',
+        _pathParams: ['id'],
+        _queryParams: ['include']
       };
 
       mockSaasClient.call.mockResolvedValue({ id: '123', name: 'John' });

--- a/src/lib/openapi-loader.ts
+++ b/src/lib/openapi-loader.ts
@@ -106,17 +106,24 @@ export class OpenAPILoader {
       required: [] as string[]
     };
 
+    // Store parameter types for proper handling in MCP handler
+    const pathParams: string[] = [];
+    const queryParams: string[] = [];
+    const bodyParams: string[] = [];
+
     // Path parameters
     if (operation.parameters) {
       for (const param of operation.parameters) {
         if (param.in === 'path') {
           inputSchema.properties[param.name] = this.parameterToSchema(param);
           inputSchema.required.push(param.name);
+          pathParams.push(param.name);
         } else if (param.in === 'query') {
           inputSchema.properties[param.name] = this.parameterToSchema(param);
           if (param.required) {
             inputSchema.required.push(param.name);
           }
+          queryParams.push(param.name);
         }
       }
     }
@@ -132,9 +139,16 @@ export class OpenAPILoader {
           if (bodySchema.required) {
             inputSchema.required.push(...bodySchema.required);
           }
+          bodyParams.push(...Object.keys(bodySchema.properties));
         }
       }
     }
+
+    // Store parameter type information for MCP handler
+    tool._pathParams = pathParams;
+    tool._queryParams = queryParams;
+    tool._bodyParams = bodyParams;
+    
 
     // Always add inputSchema, even if empty (required by Claude Desktop)
     tool.inputSchema = inputSchema;

--- a/src/lib/openapi-loader.ts
+++ b/src/lib/openapi-loader.ts
@@ -165,7 +165,7 @@ export class OpenAPILoader {
         const bodySchema = this.resolveSchema(jsonContent.schema, spec);
         
         if (bodySchema.type === 'array') {
-          // Handle array request body (like PATCH /members/v1/member/{id})
+          // Handle array request body
           inputSchema.properties.body = {
             type: 'array',
             description: 'Request body as array',

--- a/src/lib/saas-client.ts
+++ b/src/lib/saas-client.ts
@@ -58,7 +58,18 @@ export class SaaSAPIClient {
         }
         
         const errorText = await response.text();
-        throw new Error(`API request failed: ${response.status} ${response.statusText} - ${errorText}`);
+        
+        let errorDetails = errorText;
+        try {
+          const errorJson = JSON.parse(errorText);
+          if (errorJson.errors || errorJson.details || errorJson.violations) {
+            errorDetails = JSON.stringify(errorJson, null, 2);
+          }
+        } catch (e) {
+          // Not JSON, use as is
+        }
+        
+        throw new Error(`API request failed: ${response.status} ${response.statusText} - ${errorDetails}`);
       }
 
       const contentType = response.headers.get('content-type');

--- a/src/lib/saas-client.ts
+++ b/src/lib/saas-client.ts
@@ -13,9 +13,10 @@ export class SaaSAPIClient {
   async call(endpoint: string, options: APIRequestOptions = {}, authRetryCount: number = 0): Promise<any> {
     const { method = 'GET', params, body, headers = {} } = options;
     
+    
     let url = `${this.apiBaseUrl}${endpoint}`;
     
-    if (params && method === 'GET') {
+    if (params && Object.keys(params).length > 0) {
       const queryParams = new URLSearchParams();
       
       // Handle array parameters correctly

--- a/src/types/mcp.ts
+++ b/src/types/mcp.ts
@@ -13,6 +13,9 @@ export interface MCPToolDefinition {
   _apiEndpoint?: string;
   _method?: string;
   _contentType?: string;
+  _pathParams?: string[];
+  _queryParams?: string[];
+  _bodyParams?: string[];
 }
 
 export interface MCPResourceDefinition {

--- a/src/types/openapi.ts
+++ b/src/types/openapi.ts
@@ -102,6 +102,9 @@ export interface MCPTool {
   _apiEndpoint?: string;
   _method?: string;
   _contentType?: string;
+  _pathParams?: string[];
+  _queryParams?: string[];
+  _bodyParams?: string[];
 }
 
 export interface OpenAPILoaderOptions {


### PR DESCRIPTION
Fix array body parameter handling and make connector fully generic

  Summary

  This PR fixes a critical issue where array request bodies were being incorrectly wrapped in an object, causing 400 errors for APIs that
  expect direct array bodies. Additionally, it removes all API-specific code to make the connector truly generic for any OpenAPI specification.

  Changes Made

  🐛 Bug Fixes

  - Fixed array body parameter handling: Arrays are now sent directly without being wrapped in {"body": [...]} format
  - Improved path parameter detection: Now dynamically extracts path parameters from URL templates (e.g., /users/{id}) instead of using
  hardcoded parameter names
  - Enhanced error response parsing: Better formatting of error details for debugging

  ✨ New Features

  - Added OpenAPI inspection tools: 4 new MCP tools for inspecting OpenAPI specifications
    - get_openapi_spec: Get the complete OpenAPI specification
    - get_generated_tools_info: Get information about generated tools with parameter classifications
    - get_api_endpoints_summary: Get a summary of all available API endpoints
    - search_api_endpoints: Search and filter API endpoints by method, path, or operation ID

  🔧 Improvements

  - Made connector fully generic: Removed all API-specific references, error handling, and comments
  - Added support for oneOf/anyOf schemas: Better handling of complex OpenAPI schemas
  - Path-level parameter support: Now recognizes parameters defined at the path level, not just operation level

  Technical Details

  - The array body conversion logic was moved outside the fallback condition to ensure it always executes
  - Path parameters are now extracted using regex pattern matching on {param} placeholders
  - Added comprehensive parameter type classification (path, query, body) for better request routing

  Testing

  - All existing tests pass ✅
  - The connector now works correctly with APIs that expect array request bodies
  - Compatible with any OpenAPI 3.0+ specification

  Breaking Changes

  None - all changes are backward compatible
